### PR TITLE
Message body size calculation uses wrong method

### DIFF
--- a/sqs_client/SQSClientExtended.py
+++ b/sqs_client/SQSClientExtended.py
@@ -104,7 +104,7 @@ class SQSClientExtended(object):
 
 	def __is_large(self, message, message_attributes):
 		msg_attributes_size = self.__get_msg_attributes_size(message_attributes)
-		msg_body_size = self.__get_msg_attributes_size(message)
+		msg_body_size = self.__get_string_size_in_bytes(message)
 		total_msg_size = msg_attributes_size + msg_body_size
 		return (total_msg_size > self.message_size_threshold)
 


### PR DESCRIPTION
In `SQSClientExtended.__is_large(_, _)`, `msg_body_size` is calculated using `__get_msg_attributes_size(message)`.
This results in an `AttributeError`.

Proposition:
Use `__get_string_size_in_bytes(message)` instead.

Steps to reproduce:

```
sqs = SQSClientExtended(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, BUCKET_NAME)
sqs.always_through_s3 = False

sqs.send_message(AWS_SQS_QUEUE_URL, "random test string")
```
