### PR TITLE
Adds FIFO queue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Install using pip...
 ```pip install pysqs-extended-client```
 
 ## Usage
+
+### Standard Queues
+
 ```
     import base64
 
@@ -55,6 +58,45 @@ Install using pip...
             message = encoded_string.decode("utf-8")
     
         sqs.send_message(AWS_SQS_QUEUE_URL, message)
+    
+        res = sqs.receive_message(AWS_SQS_QUEUE_URL)
+    
+        for message in res:
+            sqs.delete_message(AWS_SQS_QUEUE_URL, message.get('ReceiptHandle'))
+
+```
+
+### FIFO queues
+
+```
+    import base64
+    import uuid
+
+    from pysqs_extended_client.SQSClientExtended import SQSClientExtended
+    
+    # from string import ascii_letters, digits
+    # from random import choice
+    
+    from pysqs_extended_client.config import (AWS_SQS_QUEUE_URL, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION)
+    
+    if __name__ == '__main__':
+    
+        sqs = SQSClientExtended(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, 'tiptapcode-sqs-data')
+    
+        # _100mb_large_string = ''.join([choice(ascii_letters + digits) for i in range(104857600)])
+    
+        # message = "_100mb_large_string"
+    
+        message = None
+        with open("C:\\DjangoCourse\\Courses\\celery\\introduction-promo.mp4", "rb") as image_file:
+            encoded_string = base64.b64encode(image_file.read())
+            message = encoded_string.decode("utf-8")
+
+        # Create group and deduplication IDs, required for FIFO queues.
+    		message_group_id = str(uuid.uuid4())
+        message_deduplication_id = str(uuid.uuid4())
+
+        sqs.send_message(AWS_SQS_QUEUE_URL, message, message_group_id=message_group_id, message_deduplication_id=message_deduplication_id)
     
         res = sqs.receive_message(AWS_SQS_QUEUE_URL)
     

--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -195,8 +195,8 @@ class SQSClientExtended(object):
 		if message is None:
 			raise ValueError('message_body required')
 
-                if not all([message_group_id, message_duplication_id]) and any([message_group_id, message_duplication_id]):
-                        raise ValueError('message_group_id and message_duplication_id are conditionally required together')
+		if not all([message_group_id, message_duplication_id]) and any([message_group_id, message_duplication_id]):
+		        raise ValueError('message_group_id and message_duplication_id are conditionally required together')
 
 		msg_attributes_size = self.__get_msg_attributes_size(message_attributes)
 		if msg_attributes_size > self.message_size_threshold:

--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -187,13 +187,16 @@ class SQSClientExtended(object):
 		print("receipt_handle={}".format(receipt_handle))
 		self.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
-	def send_message(self, queue_url, message, message_attributes={}):
+	def send_message(self, queue_url, message, message_group_id=None, message_deduplication_id=None, message_attributes={}):
 		"""
 		Delivers a message to the specified queue and uploads the message payload
 		to Amazon S3 if necessary.
 		"""
 		if message is None:
 			raise ValueError('message_body required')
+
+                if not all([message_group_id, message_duplication_id]) and any([message_group_id, message_duplication_id]):
+                        raise ValueError('message_group_id and message_duplication_id are conditionally required together')
 
 		msg_attributes_size = self.__get_msg_attributes_size(message_attributes)
 		if msg_attributes_size > self.message_size_threshold:
@@ -212,9 +215,9 @@ class SQSClientExtended(object):
 				raise ValueError('S3 bucket name cannot be null')
 			s3_key_message = json.dumps(self.__store_message_in_s3(message))
 			message_attributes[SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME.value] = {'StringValue': str(self.__get_string_size_in_bytes(message)), 'DataType': 'Number'}
-			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=s3_key_message, MessageAttributes=message_attributes)
+			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=s3_key_message, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
 		else:
-			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageAttributes=message_attributes)
+			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
 
 	def __store_message_in_s3(self, message_body):
 		"""

--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -195,8 +195,8 @@ class SQSClientExtended(object):
 		if message is None:
 			raise ValueError('message_body required')
 
-		if not all([message_group_id, message_duplication_id]) and any([message_group_id, message_duplication_id]):
-		        raise ValueError('message_group_id and message_duplication_id are conditionally required together')
+		if not all([message_group_id, message_deduplication_id]) and any([message_group_id, message_deduplication_id]):
+		        raise ValueError('message_group_id and message_deduplication_id are conditionally required together')
 
 		msg_attributes_size = self.__get_msg_attributes_size(message_attributes)
 		if msg_attributes_size > self.message_size_threshold:

--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -187,6 +187,12 @@ class SQSClientExtended(object):
 		print("receipt_handle={}".format(receipt_handle))
 		self.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
+	def _send_queue_message(self, queue_url, message_body, message_group_id, message_deduplication_id, message_attributes, fifo_queue):
+		if fifo_queue:
+			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
+		else:
+			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageAttributes=message_attributes)
+
 	def send_message(self, queue_url, message, message_group_id=None, message_deduplication_id=None, message_attributes={}):
 		"""
 		Delivers a message to the specified queue and uploads the message payload
@@ -195,8 +201,12 @@ class SQSClientExtended(object):
 		if message is None:
 			raise ValueError('message_body required')
 
-		if not all([message_group_id, message_deduplication_id]) and any([message_group_id, message_deduplication_id]):
-		        raise ValueError('message_group_id and message_deduplication_id are conditionally required together')
+		fifo_queue = True
+		if not all([message_group_id, message_deduplication_id]):
+			if any([message_group_id, message_deduplication_id]):
+			        raise ValueError('message_group_id and message_deduplication_id are conditionally required together')
+			else:
+				fifo_queue = False
 
 		msg_attributes_size = self.__get_msg_attributes_size(message_attributes)
 		if msg_attributes_size > self.message_size_threshold:
@@ -215,9 +225,9 @@ class SQSClientExtended(object):
 				raise ValueError('S3 bucket name cannot be null')
 			s3_key_message = json.dumps(self.__store_message_in_s3(message))
 			message_attributes[SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME.value] = {'StringValue': str(self.__get_string_size_in_bytes(message)), 'DataType': 'Number'}
-			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=s3_key_message, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
+			return self._send_queue_message(queue_url, s3_key_message, message_group_id, message_deduplication_id, message_attributes, fifo_queue)	
 		else:
-			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
+			return self._send_queue_message(queue_url, s3_key_message, message_group_id, message_deduplication_id, message_attributes, fifo_queue)	
 
 	def __store_message_in_s3(self, message_body):
 		"""

--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -187,11 +187,15 @@ class SQSClientExtended(object):
 		print("receipt_handle={}".format(receipt_handle))
 		self.sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
-	def _send_queue_message(self, queue_url, message_body, message_group_id, message_deduplication_id, message_attributes, fifo_queue):
-		if fifo_queue:
-			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
+	def _send_queue_message(self, queue_url, message_body, message_group_id, message_deduplication_id, message_attributes, is_fifo_queue):
+		"""
+		Helper function to send message to a regular queue vs. a fifo queue, depending on is_fifo_queue parameter.
+		is_fifo_queue determined by initial send_message call's message_group_id and message_deduplication_id parameters.
+		"""
+		if is_fifo_queue:
+			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message_body, MessageGroupId=message_group_id, MessageDeduplicationId=message_deduplication_id, MessageAttributes=message_attributes)
 		else:
-			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message, MessageAttributes=message_attributes)
+			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message_body, MessageAttributes=message_attributes)
 
 	def send_message(self, queue_url, message, message_group_id=None, message_deduplication_id=None, message_attributes={}):
 		"""


### PR DESCRIPTION
# Description

Adds support for FIFO queues to SQSClientExtended. Includes some slight refactoring to avoid implementing the same logic multiple times.

Fixes #11

### PR type

- [x] Feature
- [ ] TechDebt
- [ ] Bugfix
- [ ] Other

### Changelog updated

- [ ] Yes
- [x] No

There are no current changelog entries, so I am unsure of the format.

### Breaking changes

- [ ] Yes
- [x] No

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Pushed to a FIFO queue with message group and deduplication IDs, and it worked
- [x] Pushed to a FIFO queue without message group and deduplication IDs, and it failed (expected)
- [x] Pushed to a standard queue with message group and deduplication IDs and it worked
- [x] Pushed to a standard queue without message group and deduplication IDs and it worked.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] PR has been appropriately with a meaning tag
  - There are no current tags, so I can't add one.