### PR TITLE
Fix ValueError on message_attribute default value

### DIFF
--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -202,10 +202,14 @@ class SQSClientExtended(object):
 		Delivers a message to the specified queue and uploads the message payload
 		to Amazon S3 if necessary.
 		"""
-		if message is None:
+
+                if not message_attributes:
+                    message_attributes = {}
+
+                if message is None:
 			raise ValueError('message_body required')
 
-		fifo_queue = True
+                fifo_queue = True
 		if not all([message_group_id, message_deduplication_id]):
 			if any([message_group_id, message_deduplication_id]):
 			        raise ValueError('message_group_id and message_deduplication_id are conditionally required together')

--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -202,7 +202,6 @@ class SQSClientExtended(object):
 		Delivers a message to the specified queue and uploads the message payload
 		to Amazon S3 if necessary.
 		"""
-
                 if not message_attributes:
                     message_attributes = {}
 


### PR DESCRIPTION
# Description

I pulled the repo to use the recently added FIFO queue option. When I followed the README example, I received the following error when I did not explicitly set "message_attributes={}" in send_messages.
```
ValueError: Message attribute name SQSLargePayloadSize is reserved for use by SQS extended client.
```
Looks like it has to do with the default value being mutable. 

Fixes # (issue)
I created an empty dictionary if the default parameter is empty, and this resolved the issue.

### PR type

- [ ] Feature
- [ ] TechDebt
- [X] Bugfix
- [ ] Other

### Changelog updated

- [ ] Yes
- [X] No

### Breaking changes

- [ ] Yes
- [X] No

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] tox

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] PR has been appropriately with a meaning tag