### PR TITLE
Fix case when message body is a list

### DIFF
--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -129,6 +129,8 @@ class SQSClientExtended(object):
 			if large_pay_load_attribute_value:
 				try:
 					message_body = json.loads(message.get('Body'))
+					if isinstance(message_body, list) and message_body[0] == "software.amazon.payloadoffloading.PayloadS3Pointer":
+						message_body = message_body[1]
 					if 's3BucketName' not in message_body and 's3Key' not in message_body:
 						raise ValueError('Detected missing required key attribute s3BucketName and s3Key in s3 payload')
 					s3_bucket_name = message_body.get('s3BucketName')


### PR DESCRIPTION
When message body is e.g.
    [
      "software.amazon.payloadoffloading.PayloadS3Pointer",
      {
        "s3BucketName": "my-ssq-bucket",
        "s3Key": "af678f3c-ac46-4539-94d6-eac3c5e60db4"
      }
    ]

message parsing fails due to it not finding the keys "s3BucketName" and
"s3Key" in the body.

This commit changes so that we check if the body is a list, and the first
element of the list is the string
"software.amazon.payloadoffloading.PayloadS3Pointer".

If the body is not a list we fall back to the old behavior.

Fixes #7

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

### PR type

- [ ] Feature
- [ ] TechDebt
- [x] Bugfix
- [ ] Other

### Changelog updated

- [ ] Yes
- [x] No

### Breaking changes

- [ ] Yes
- [x] No

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] I have tested this in a live environment, as this fix was needed in order for our messaging to function.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] PR has been appropriately with a meaning tag