### PR TITLE
message attributes setting from previous call

### DIFF
--- a/pysqs_extended_client/SQSClientExtended.py
+++ b/pysqs_extended_client/SQSClientExtended.py
@@ -199,7 +199,7 @@ class SQSClientExtended(object):
 		else:
 			return self.sqs.send_message(QueueUrl=queue_url, MessageBody=message_body, MessageAttributes=message_attributes)
 
-	def send_message(self, queue_url, message, message_group_id=None, message_deduplication_id=None, message_attributes={}):
+	def send_message(self, queue_url, message, message_group_id=None, message_deduplication_id=None, message_attributes=None):
 		"""
 		Delivers a message to the specified queue and uploads the message payload
 		to Amazon S3 if necessary.
@@ -207,6 +207,17 @@ class SQSClientExtended(object):
 		if message is None:
 			raise ValueError('message_body required')
 
+		"""
+                message_attributes={} is dangerous if your function will modify the argument. 
+                If you modify a default argument, it will persist until the next call, 
+                so your "empty" dict will start to contain values on calls other than the first one.
+
+                Using None is both safe and conventional in cases where arguments with default value are not passed.
+		"""			
+
+                if message_attributes is None:
+                        message_attributes = dict()
+			
 		fifo_queue = True
 		if not all([message_group_id, message_deduplication_id]):
 			if any([message_group_id, message_deduplication_id]):


### PR DESCRIPTION
Error

```
Traceback (most recent call last):
  File "sqs.py", line 25, in <module>
    send_message()
  File "sqs.py", line 17, in send_message
    raise ValueError("Message attribute name {} is reserved for use by SQS extended client.".format(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME.value))
ValueError: Message attribute name SQSLargePayloadSize is reserved for use by SQS extended client.
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

### PR type

- [ ] Feature
- [ ] TechDebt
- [x] Bugfix
- [ ] Other

### Changelog updated

- [ ] Yes
- [x] No

### Breaking changes

- [ ] Yes
- [x] No

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] PR has been appropriately with a meaning tag